### PR TITLE
Add glossary import from tags

### DIFF
--- a/.github/workflows/CI-Server.yml
+++ b/.github/workflows/CI-Server.yml
@@ -4,8 +4,11 @@ on:
   push:
     branches:
       - main
+      - work
     paths:
       - server/**
+  workflow_dispatch:
+  
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-server
@@ -40,14 +43,13 @@ jobs:
         with:
           context: server
           push: true
-          tags: ghcr.io/auto-novel/auto-novel-server:latest
+          tags: ghcr.io/dekkmarsvin/auto-novel-server:latest
 
       - name: Delete all containers from repository without tags
-        uses: Chizkiyahu/delete-untagged-ghcr-action@v2
+        uses: Chizkiyahu/delete-untagged-ghcr-action@v6
         with:
-          token: ${{ secrets.DELETE_PACKAGES_TOKEN }}
-          repository_owner: ${{ github.repository_owner }}
-          repository: ${{ github.repository }}
-          untagged_only: true
-          owner_type: user
-          except_untagged_multiplatform: true
+            token: ${{ secrets.PAT_TOKEN }}
+            repository_owner: ${{ github.repository_owner }}
+            repository: ${{ github.repository }}
+            untagged_only: true
+            owner_type: user

--- a/.github/workflows/CI-Web.yml
+++ b/.github/workflows/CI-Web.yml
@@ -4,8 +4,10 @@ on:
   push:
     branches:
       - main
+      - work
     paths:
       - web/**
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-web
@@ -40,14 +42,14 @@ jobs:
         with:
           context: web
           push: true
-          tags: ghcr.io/auto-novel/auto-novel-web:latest
-
+          tags: ghcr.io/dekkmarsvin/auto-novel-web:latest
+      
       - name: Delete all containers from repository without tags
-        uses: Chizkiyahu/delete-untagged-ghcr-action@v2
+        uses: Chizkiyahu/delete-untagged-ghcr-action@v6
         with:
-          token: ${{ secrets.DELETE_PACKAGES_TOKEN }}
-          repository_owner: ${{ github.repository_owner }}
-          repository: ${{ github.repository }}
-          untagged_only: true
-          owner_type: user
-          except_untagged_multiplatform: true
+            token: ${{ secrets.PAT_TOKEN }}
+            repository_owner: ${{ github.repository_owner }}
+            repository: ${{ github.repository }}
+            untagged_only: true
+            owner_type: user
+

--- a/server/src/main/kotlin/api/RouteWebNovel.kt
+++ b/server/src/main/kotlin/api/RouteWebNovel.kt
@@ -293,6 +293,7 @@ private val disgustingFascistNovelList = mapOf(
         "n0646ie",
         "n8926ic",
         "n4583he",
+        "n6465co",
     ),
     Kakuyomu.id to listOf(
         "16816927860373250234",
@@ -642,7 +643,6 @@ class WebNovelApi(
     ): Map<String, String> {
         val info = metadataRepo.getIdAndKeywords(providerId, novelId) ?: throwNovelNotFound()
         val glossaries = metadataRepo.listGlossaryByTags(info.keywords, info.id)
-
         val counts = mutableMapOf<String, MutableMap<String, Int>>()
         glossaries.forEach { g ->
             g.forEach { (jp, zh) ->

--- a/server/src/main/kotlin/api/RouteWenkuNovel.kt
+++ b/server/src/main/kotlin/api/RouteWenkuNovel.kt
@@ -480,7 +480,6 @@ class WenkuNovelApi(
     ): Map<String, String> {
         val info = metadataRepo.getIdAndKeywords(novelId) ?: throwNovelNotFound()
         val glossaries = metadataRepo.listGlossaryByTags(info.keywords, info.id)
-
         val counts = mutableMapOf<String, MutableMap<String, Int>>()
         glossaries.forEach { g ->
             g.forEach { (jp, zh) ->

--- a/server/src/main/kotlin/infra/web/repository/WebNovelMetadataRepository.kt
+++ b/server/src/main/kotlin/infra/web/repository/WebNovelMetadataRepository.kt
@@ -364,7 +364,7 @@ class WebNovelMetadataRepository(
         val keywords = doc.getList("keywords", String::class.java) ?: emptyList<String>()
         return IdAndKeywords(id, keywords.toList())
     }
-
+    
     suspend fun listGlossaryByTags(
         tags: List<String>,
         excludeId: ObjectId?,

--- a/server/src/main/kotlin/infra/wenku/repository/WenkuNovelMetadataRepository.kt
+++ b/server/src/main/kotlin/infra/wenku/repository/WenkuNovelMetadataRepository.kt
@@ -234,7 +234,7 @@ class WenkuNovelMetadataRepository(
         val keywords = doc.getList("keywords", String::class.java) ?: emptyList<String>()
         return IdAndKeywords(id, keywords.toList())
     }
-
+    
     suspend fun listGlossaryByTags(
         tags: List<String>,
         excludeId: ObjectId?,


### PR DESCRIPTION
## Summary
- allow importing glossary terms from novels sharing keywords
- expose new endpoints in server for tag-based glossary import
- support fetching via web or wenku repositories
- add UI button to import glossary from tag
- fix glossary-by-tag projection to avoid deserializing missing fields

## Testing
- `pnpm lint`
- `pnpm test`
- `./gradlew test` *(fails: Cannot find a Java installation)*

------
https://chatgpt.com/codex/tasks/task_e_68677a0297908322aef046b8431e4ca2