### PR TITLE
Fix tag glossary import rule

### DIFF
--- a/server/src/main/kotlin/api/RouteWebNovel.kt
+++ b/server/src/main/kotlin/api/RouteWebNovel.kt
@@ -651,7 +651,10 @@ class WebNovelApi(
             }
         }
 
-        return counts.mapValues { it.value.maxByOrNull { p -> p.value }!!.key }
+        return counts.mapNotNull { (jp, m) ->
+            val (zh, c) = m.maxByOrNull { it.value }!!
+            if (c > 1) jp to zh else null
+        }.toMap()
     }
 
     // File

--- a/server/src/main/kotlin/api/RouteWenkuNovel.kt
+++ b/server/src/main/kotlin/api/RouteWenkuNovel.kt
@@ -488,7 +488,10 @@ class WenkuNovelApi(
             }
         }
 
-        return counts.mapValues { it.value.maxByOrNull { p -> p.value }!!.key }
+        return counts.mapNotNull { (jp, m) ->
+            val (zh, c) = m.maxByOrNull { it.value }!!
+            if (c > 1) jp to zh else null
+        }.toMap()
     }
 
     private suspend fun validateNovelId(novelId: String) {


### PR DESCRIPTION
## Summary
- filter out tag glossaries that appear in only one novel

## Testing
- `./gradlew test --no-daemon` *(fails: cannot find Java 17 toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68681c1281d883229b22c77ad59dcc01