### PR TITLE
Fix tag glossary import rule

### DIFF
--- a/server/src/main/kotlin/api/RouteWebNovel.kt
+++ b/server/src/main/kotlin/api/RouteWebNovel.kt
@@ -28,6 +28,7 @@ import io.ktor.server.resources.put
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
 import io.ktor.util.*
+import util.japaneseTermThreshold
 import kotlinx.serialization.Serializable
 import org.bson.types.ObjectId
 import org.koin.ktor.ext.inject
@@ -651,7 +652,11 @@ class WebNovelApi(
             }
         }
 
-        return counts.mapValues { it.value.maxByOrNull { p -> p.value }!!.key }
+        return counts.mapNotNull { (jp, m) ->
+            val (zh, c) = m.maxByOrNull { it.value }!!
+            val threshold = util.japaneseTermThreshold(jp)
+            if (c >= threshold) jp to zh else null
+        }.toMap()
     }
 
     // File

--- a/server/src/main/kotlin/api/RouteWenkuNovel.kt
+++ b/server/src/main/kotlin/api/RouteWenkuNovel.kt
@@ -22,6 +22,7 @@ import io.ktor.server.request.*
 import io.ktor.server.resources.*
 import io.ktor.server.resources.post
 import io.ktor.server.resources.put
+import util.japaneseTermThreshold
 import io.ktor.server.routing.*
 import io.ktor.utils.io.*
 import kotlinx.serialization.Serializable
@@ -488,7 +489,11 @@ class WenkuNovelApi(
             }
         }
 
-        return counts.mapValues { it.value.maxByOrNull { p -> p.value }!!.key }
+        return counts.mapNotNull { (jp, m) ->
+            val (zh, c) = m.maxByOrNull { it.value }!!
+            val threshold = util.japaneseTermThreshold(jp)
+            if (c >= threshold) jp to zh else null
+        }.toMap()
     }
 
     private suspend fun validateNovelId(novelId: String) {

--- a/server/src/main/kotlin/util/JpScript.kt
+++ b/server/src/main/kotlin/util/JpScript.kt
@@ -1,0 +1,7 @@
+package util
+
+private val kanjiOrKatakana = Regex("[\\p{IsHan}\\p{IsKatakana}]")
+
+fun japaneseTermThreshold(term: String): Int {
+    return if (kanjiOrKatakana.containsMatchIn(term)) 3 else 10
+}


### PR DESCRIPTION
## Summary
- filter out tag glossaries that appear in only one novel
- further restrict tag glossary import by requiring 3 appearances for terms with kanji or katakana, or 10 if only hiragana

## Testing
- `./gradlew test --no-daemon` *(fails to find Java 17 toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68681c1281d883229b22c77ad59dcc01