### PR TITLE
Add admin glossary manager

### DIFF
--- a/server/src/main/kotlin/Application.kt
+++ b/server/src/main/kotlin/Application.kt
@@ -83,6 +83,7 @@ fun main() {
             routeArticle()
             routeComment()
             routeOperationHistory()
+            routeTagGlossary()
             //
             routeUser()
             routeUserFavoredWeb()
@@ -141,6 +142,7 @@ val appModule = module {
     singleOf(::ArticleRepository)
     singleOf(::CommentRepository)
     singleOf(::OperationHistoryRepository)
+    singleOf(::TagGlossaryRepository)
 
     singleOf(::UserRepository)
     singleOf(::UserCodeRepository)
@@ -165,6 +167,7 @@ val appModule = module {
     singleOf(::ArticleApi)
     singleOf(::CommentApi)
     singleOf(::OperationHistoryApi)
+    singleOf(::TagGlossaryApi)
 
     singleOf(::UserApi)
     singleOf(::UserFavoredWebApi)

--- a/server/src/main/kotlin/api/RouteGlossary.kt
+++ b/server/src/main/kotlin/api/RouteGlossary.kt
@@ -1,0 +1,118 @@
+package api
+
+import api.plugins.authenticateDb
+import api.plugins.shouldBeAtLeast
+import api.plugins.shouldBeOldAss
+import api.plugins.user
+import infra.glossary.TagGlossary
+import infra.glossary.TagGlossaryRepository
+import infra.user.User
+import infra.user.UserRole
+import io.ktor.resources.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.resources.*
+import io.ktor.server.resources.delete
+import io.ktor.server.resources.post
+import io.ktor.server.resources.put
+import io.ktor.server.routing.*
+import kotlinx.serialization.Serializable
+import org.bson.types.ObjectId
+import org.koin.ktor.ext.inject
+
+@Resource("/tag-glossary")
+private class TagGlossaryRes {
+    @Resource("")
+    class List(val parent: TagGlossaryRes, val tag: String? = null)
+
+    @Resource("/{id}")
+    class Id(val parent: TagGlossaryRes, val id: String)
+}
+
+fun Route.routeTagGlossary() {
+    val api by inject<TagGlossaryApi>()
+
+    authenticateDb {
+        get<TagGlossaryRes.List> { loc ->
+            val user = call.user()
+            call.tryRespond { api.list(user, loc.tag) }
+        }
+        post<TagGlossaryRes.List> { _ ->
+            val user = call.user()
+            val body = call.receive<TagGlossaryApi.CreateBody>()
+            call.tryRespond { api.create(user, body) }
+        }
+        put<TagGlossaryRes.Id> { loc ->
+            val user = call.user()
+            val body = call.receive<TagGlossaryApi.UpdateBody>()
+            call.tryRespond { api.update(user, loc.id, body) }
+        }
+        delete<TagGlossaryRes.Id> { loc ->
+            val user = call.user()
+            call.tryRespond { api.delete(user, loc.id) }
+        }
+    }
+}
+
+class TagGlossaryApi(private val repo: TagGlossaryRepository) {
+    @Serializable
+    data class TagGlossaryDto(
+        val id: String,
+        val tag: String,
+        val glossary: Map<String, String>,
+        val adminOnly: Boolean,
+    )
+
+    suspend fun list(user: User, tag: String?): List<TagGlossaryDto> {
+        user.shouldBeAtLeast(UserRole.Admin)
+        return repo.list(tag).map {
+            TagGlossaryDto(
+                id = it.id.toHexString(),
+                tag = it.tag,
+                glossary = it.glossary,
+                adminOnly = it.adminOnly,
+            )
+        }
+    }
+
+    @Serializable
+    data class CreateBody(
+        val tag: String,
+        val glossary: Map<String, String>,
+        val adminOnly: Boolean = false,
+    )
+
+    suspend fun create(user: User, body: CreateBody): String {
+        user.shouldBeAtLeast(UserRole.Admin)
+        return repo.create(body.tag, body.glossary, body.adminOnly).toHexString()
+    }
+
+    @Serializable
+    data class UpdateBody(
+        val glossary: Map<String, String>,
+        val adminOnly: Boolean? = null,
+    )
+
+    suspend fun update(user: User, id: String, body: UpdateBody) {
+        val g = repo.get(id) ?: return
+        if (g.adminOnly) {
+            user.shouldBeAtLeast(UserRole.Admin)
+        } else {
+            user.shouldBeAtLeast(UserRole.Admin)
+        }
+        repo.update(id, body.glossary, body.adminOnly)
+    }
+
+    suspend fun delete(user: User, id: String) {
+        val g = repo.get(id) ?: return
+        if (g.adminOnly) {
+            user.shouldBeAtLeast(UserRole.Admin)
+        } else {
+            user.shouldBeAtLeast(UserRole.Admin)
+        }
+        repo.delete(id)
+    }
+
+    suspend fun listByTags(tags: List<String>): List<Map<String, String>> =
+        repo.listByTags(tags).map { it.glossary }
+}

--- a/server/src/main/kotlin/api/RouteWebNovel.kt
+++ b/server/src/main/kotlin/api/RouteWebNovel.kt
@@ -9,6 +9,7 @@ import infra.oplog.OperationHistoryRepository
 import infra.user.User
 import infra.user.UserFavoredRepository
 import infra.web.*
+import infra.glossary.TagGlossaryRepository
 import infra.web.datasource.providers.Hameln
 import infra.web.datasource.providers.Kakuyomu
 import infra.web.datasource.providers.NovelIdShouldBeReplacedException
@@ -329,6 +330,7 @@ class WebNovelApi(
     private val historyRepo: WebNovelReadHistoryRepository,
     private val wenkuMetadataRepo: WenkuNovelMetadataRepository,
     private val operationHistoryRepo: OperationHistoryRepository,
+    private val tagGlossaryRepo: TagGlossaryRepository,
 ) {
     suspend fun list(
         user: User?,
@@ -643,7 +645,8 @@ class WebNovelApi(
         novelId: String,
     ): Map<String, String> {
         val info = metadataRepo.getIdAndKeywords(providerId, novelId) ?: throwNovelNotFound()
-        val glossaries = metadataRepo.listGlossaryByTags(info.keywords, info.id)
+        val glossaries = metadataRepo.listGlossaryByTags(info.keywords, info.id) +
+            tagGlossaryRepo.listByTags(info.keywords).map { it.glossary }
         val counts = mutableMapOf<String, MutableMap<String, Int>>()
         glossaries.forEach { g ->
             g.forEach { (jp, zh) ->

--- a/server/src/main/kotlin/infra/MongoClient.kt
+++ b/server/src/main/kotlin/infra/MongoClient.kt
@@ -97,6 +97,8 @@ object MongoCollectionNames {
     const val SAKURA_WEB_INCORRECT_CASE = "sakura-incorrect-case"
     const val USER = "user"
 
+    const val GLOSSARY = "glossary"
+
     const val WEB_NOVEL = "metadata"
     const val WEB_FAVORITE = "web-favorite"
     const val WEB_READ_HISTORY = "web-read-history"

--- a/server/src/main/kotlin/infra/glossary/TagGlossary.kt
+++ b/server/src/main/kotlin/infra/glossary/TagGlossary.kt
@@ -1,0 +1,14 @@
+package infra.glossary
+
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.bson.types.ObjectId
+
+@Serializable
+data class TagGlossary(
+    @Contextual @SerialName("_id") val id: ObjectId,
+    val tag: String,
+    val glossary: Map<String, String>,
+    val adminOnly: Boolean = false,
+)

--- a/server/src/main/kotlin/infra/glossary/TagGlossaryRepository.kt
+++ b/server/src/main/kotlin/infra/glossary/TagGlossaryRepository.kt
@@ -1,0 +1,53 @@
+package infra.glossary
+
+import com.mongodb.client.model.Filters.`in`
+import com.mongodb.client.model.Filters.eq
+import com.mongodb.client.model.Projections.include
+import com.mongodb.client.model.Updates.combine
+import com.mongodb.client.model.Updates.set
+import infra.MongoClient
+import infra.MongoCollectionNames
+import infra.aggregate
+import infra.field
+import infra.fieldPath
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.toList
+import org.bson.conversions.Bson
+import org.bson.types.ObjectId
+
+class TagGlossaryRepository(mongo: MongoClient) {
+    private val col = mongo.database.getCollection<TagGlossary>(MongoCollectionNames.GLOSSARY)
+
+    suspend fun list(tag: String?): List<TagGlossary> {
+        return if (tag != null) {
+            col.find(eq(TagGlossary::tag.field(), tag)).toList()
+        } else {
+            col.find().toList()
+        }
+    }
+
+    suspend fun listByTags(tags: List<String>): List<TagGlossary> {
+        if (tags.isEmpty()) return emptyList()
+        return col.find(`in`(TagGlossary::tag.field(), tags)).toList()
+    }
+
+    suspend fun get(id: String): TagGlossary? {
+        return col.find(eq(TagGlossary::id.field(), ObjectId(id))).firstOrNull()
+    }
+
+    suspend fun create(tag: String, glossary: Map<String, String>, adminOnly: Boolean): ObjectId {
+        val id = ObjectId()
+        col.insertOne(TagGlossary(id, tag, glossary, adminOnly))
+        return id
+    }
+
+    suspend fun update(id: String, glossary: Map<String, String>, adminOnly: Boolean?) {
+        val updates = mutableListOf<Bson>(set(TagGlossary::glossary.field(), glossary))
+        if (adminOnly != null) updates.add(set(TagGlossary::adminOnly.field(), adminOnly))
+        col.updateOne(eq(TagGlossary::id.field(), ObjectId(id)), combine(updates))
+    }
+
+    suspend fun delete(id: String) {
+        col.deleteOne(eq(TagGlossary::id.field(), ObjectId(id)))
+    }
+}

--- a/web/src/data/api/TagGlossaryRepository.ts
+++ b/web/src/data/api/TagGlossaryRepository.ts
@@ -1,0 +1,30 @@
+import { client } from './client';
+
+export interface TagGlossary {
+  id: string;
+  tag: string;
+  glossary: { [key: string]: string };
+  adminOnly: boolean;
+}
+
+const list = () => client.get('tag-glossary').json<TagGlossary[]>();
+
+const create = (json: {
+  tag: string;
+  glossary: { [key: string]: string };
+  adminOnly: boolean;
+}) => client.post('tag-glossary', { json }).text();
+
+const update = (
+  id: string,
+  json: { glossary: { [key: string]: string }; adminOnly?: boolean },
+) => client.put(`tag-glossary/${id}`, { json });
+
+const remove = (id: string) => client.delete(`tag-glossary/${id}`);
+
+export const TagGlossaryRepository = {
+  list,
+  create,
+  update,
+  remove,
+};

--- a/web/src/data/api/index.ts
+++ b/web/src/data/api/index.ts
@@ -6,6 +6,7 @@ export { OperationRepository } from './OperationRepository';
 export { UserRepository } from './UserRepository';
 export { WebNovelRepository } from './WebNovelRepository';
 export { WenkuNovelRepository } from './WenkuNovelRepository';
+export { TagGlossaryRepository } from './TagGlossaryRepository';
 
 export const formatError = (error: unknown) => {
   if (error instanceof HTTPError) {

--- a/web/src/pages/admin/AdminGlossaryManagement.vue
+++ b/web/src/pages/admin/AdminGlossaryManagement.vue
@@ -1,0 +1,121 @@
+<script lang="ts" setup>
+import { TagGlossaryRepository } from '@/data/api';
+import type { TagGlossary } from '@/data/api/TagGlossaryRepository';
+import { Result, runCatching } from '@/util/result';
+import { Glossary } from '@/model/Glossary';
+import { useMessage } from 'naive-ui';
+
+const glossariesResult = ref<Result<TagGlossary[]>>();
+const message = useMessage();
+
+const load = async () => {
+  glossariesResult.value = await runCatching(TagGlossaryRepository.list());
+};
+
+onMounted(load);
+
+const showEdit = ref(false);
+const editItem = ref<TagGlossary>();
+const editRaw = ref('');
+const editAdminOnly = ref(false);
+
+const openEdit = (item: TagGlossary) => {
+  editItem.value = item;
+  editRaw.value = Glossary.toText(item.glossary);
+  editAdminOnly.value = item.adminOnly;
+  showEdit.value = true;
+};
+
+const submitEdit = async () => {
+  if (!editItem.value) return;
+  const g = Glossary.fromText(editRaw.value);
+  if (!g) {
+    message.error('术语表格式错误');
+    return;
+  }
+  await TagGlossaryRepository.update(editItem.value.id, {
+    glossary: g,
+    adminOnly: editAdminOnly.value,
+  });
+  editItem.value.glossary = g;
+  editItem.value.adminOnly = editAdminOnly.value;
+  showEdit.value = false;
+};
+
+const newTag = ref('');
+const newRaw = ref('');
+const newAdminOnly = ref(false);
+
+const create = async () => {
+  const g = Glossary.fromText(newRaw.value);
+  if (!g) {
+    message.error('术语表格式错误');
+    return;
+  }
+  await TagGlossaryRepository.create({
+    tag: newTag.value,
+    glossary: g,
+    adminOnly: newAdminOnly.value,
+  });
+  newTag.value = '';
+  newRaw.value = '';
+  newAdminOnly.value = false;
+  await load();
+};
+
+const remove = async (id: string) => {
+  await TagGlossaryRepository.remove(id);
+  if (glossariesResult.value?.ok) {
+    glossariesResult.value.value = glossariesResult.value.value.filter(
+      (it) => it.id !== id,
+    );
+  }
+};
+</script>
+
+<template>
+  <n-button type="primary" @click="load">刷新</n-button>
+  <n-divider />
+  <n-table v-if="glossariesResult?.ok" :bordered="false">
+    <thead>
+      <tr>
+        <th>tag</th>
+        <th>adminOnly</th>
+        <th>terms</th>
+        <th>操作</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="g in glossariesResult.value" :key="g.id">
+        <td>{{ g.tag }}</td>
+        <td>{{ g.adminOnly }}</td>
+        <td>{{ Object.keys(g.glossary).length }}</td>
+        <td>
+          <n-button size="small" @click="openEdit(g)">编辑</n-button>
+          <n-button size="small" type="error" @click="remove(g.id)">
+            删除
+          </n-button>
+        </td>
+      </tr>
+    </tbody>
+  </n-table>
+
+  <n-modal v-model:show="showEdit" preset="dialog" title="编辑术语表">
+    <n-input v-model:value="editRaw" type="textarea" :rows="5" />
+    <n-checkbox v-model:checked="editAdminOnly">仅管理员可改</n-checkbox>
+    <template #action>
+      <n-button type="primary" @click="submitEdit">提交</n-button>
+    </template>
+  </n-modal>
+
+  <n-divider />
+  <n-h3>新建术语表</n-h3>
+  <n-form-item label="Tag"><n-input v-model:value="newTag" /></n-form-item>
+  <n-form-item label="内容">
+    <n-input v-model:value="newRaw" type="textarea" :rows="3" />
+  </n-form-item>
+  <n-form-item label="仅管理员可改">
+    <n-checkbox v-model:checked="newAdminOnly" />
+  </n-form-item>
+  <n-button type="primary" @click="create">创建</n-button>
+</template>

--- a/web/src/pages/admin/AdminLayout.vue
+++ b/web/src/pages/admin/AdminLayout.vue
@@ -25,6 +25,7 @@ const handleUpdateValue = (path: string) => router.push({ path });
         <n-tab name="/admin/user">用户</n-tab>
         <n-tab name="/admin/operation">操作历史</n-tab>
         <n-tab name="/admin/web-toc-merge-history">合并历史</n-tab>
+        <n-tab name="/admin/glossary">术语表管理</n-tab>
       </n-tabs>
       <router-view />
     </template>

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -275,6 +275,11 @@ const router = createRouter({
               component: () =>
                 import('./pages/admin/AdminWebTocMergeHistory.vue'),
             },
+            {
+              path: 'glossary',
+              component: () =>
+                import('./pages/admin/AdminGlossaryManagement.vue'),
+            },
           ],
         },
 


### PR DESCRIPTION
## Summary
- add `TagGlossary` Mongo collection and repository
- expose `/tag-glossary` API for admins
- integrate tag glossaries into WebNovel glossary suggestions
- update DI and routes
- add web admin page for glossary management and router/tab entries

## Testing
- `npm test`
- `./gradlew test` *(fails: Could not determine the dependencies of task :test)*

------
https://chatgpt.com/codex/tasks/task_e_68695008010883228e4e233e4ec1e4cd