### PR TITLE
Fix missing import for TagGlossaryRepository

### DIFF
--- a/server/src/main/kotlin/Application.kt
+++ b/server/src/main/kotlin/Application.kt
@@ -6,6 +6,7 @@ import infra.*
 import infra.article.ArticleRepository
 import infra.comment.CommentRepository
 import infra.oplog.OperationHistoryRepository
+import infra.glossary.TagGlossaryRepository
 import infra.web.repository.WebNovelFavoredRepository
 import infra.wenku.repository.WenkuNovelFavoredRepository
 import infra.web.repository.WebNovelReadHistoryRepository


### PR DESCRIPTION
## Summary
- import `TagGlossaryRepository` in `Application.kt`

## Testing
- `./gradlew test --no-daemon` *(fails: MongoClientTest initialization error)*

------
https://chatgpt.com/codex/tasks/task_e_686a545d256c8322b5313bbfe975cafe