### PR TITLE
Fix glossary refresh button

### DIFF
--- a/web/src/pages/admin/AdminGlossaryManagement.vue
+++ b/web/src/pages/admin/AdminGlossaryManagement.vue
@@ -76,7 +76,7 @@ const remove = async (id: string) => {
 <template>
   <n-button type="primary" @click="load">刷新</n-button>
   <n-divider />
-  <n-table v-if="glossariesResult?.ok" :bordered="false">
+  <n-table v-if="glossariesResult?.value?.ok" :bordered="false">
     <thead>
       <tr>
         <th>tag</th>


### PR DESCRIPTION
## Summary
- fix the glossary page refresh condition

## Testing
- `npm test`
- `./gradlew test` *(fails: Cannot find a Java installation)*

------
https://chatgpt.com/codex/tasks/task_e_686b40e80f2c8322a9964022f8f2a5cd