### PR TITLE
fix: correct glossary import API usage

### DIFF
--- a/web/src/components/GlossaryButton.vue
+++ b/web/src/components/GlossaryButton.vue
@@ -140,14 +140,12 @@ const importGlossaryFromTag = async () => {
   if (!gnid) return;
   let data: Glossary = {};
   if (gnid.type === 'web') {
-    data = await Locator.webNovelRepository.importGlossaryFromTag(
+    data = await WebNovelApi.importGlossaryFromTag(
       gnid.providerId,
       gnid.novelId,
     );
   } else if (gnid.type === 'wenku') {
-    data = await Locator.wenkuNovelRepository.importGlossaryFromTag(
-      gnid.novelId,
-    );
+    data = await WenkuNovelApi.importGlossaryFromTag(gnid.novelId);
   } else {
     return;
   }


### PR DESCRIPTION
## Summary
- use API modules instead of unavailable repository properties for importing glossaries

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b133bcda6883228a2fdac95d4d6982