### PR TITLE
fix: protect crawler admin endpoints

### DIFF
--- a/daemon/README.md
+++ b/daemon/README.md
@@ -26,7 +26,7 @@ On startup the service:
 
 ### API
 
-The HTTP API is exposed at `/proxies` on the crawler server.
+The HTTP API is exposed at `/proxies` on the crawler server only when an admin token is configured. Set `adminToken` in `config.json` or set `CRAWLER_ADMIN_TOKEN` in the environment to a value with at least 16 characters. Send the token as `Authorization: Bearer <token>` or `X-Admin-Token: <token>`. Without a configured token, the proxy management API and `/shutdown` endpoint are disabled.
 
 - `GET /proxies` — returns the current proxy pool with health stats.
 - `POST /proxies` — accepts JSON body matching:

--- a/daemon/config.example.json
+++ b/daemon/config.example.json
@@ -1,5 +1,5 @@
 {
-  "host": "::",
+  "host": "127.0.0.1",
   "port": 3000,
   "proxyDbPath": "data/crawler-proxies.db",
   "defaultProxies": [
@@ -30,7 +30,7 @@
     "alphapolis": {
       "headers": {
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
-        "Cookie": "0iv47h3ctpk=; 87fe7ggqpgk=; aws-waf-token=e223dc59-539f-4b43-91d8-390484641454:AQoApD4RnTORAAAA:4GUjcEZnDewQb8SZcqCJ2JUkwGKS95xM0CK+bYcJ5g+ErndUhPbVIleYjt9N+iLBOx7hUqslQ/CWRYYKDO1wWJ9qqv0sOQ6tE6AyUITBDmOqB1jj+QAmTloAFVj4kKSx4UoPoCYrlLN5ndtkaBLMMgmIfZXRXYXIRqsYMgaTkt6RvBCp2jeikSye80wfIpWR3qvTxReedfymxnjM; krt_rewrite_uid=869387cf-c68b-463e-bb8d-f44378e56d4a; twtr_pixel_opt_in=N; XSRF-TOKEN=eyJpdiI6IkYzV3dPa2RWb1hVOWpWZU1lQlNMM1E9PSIsInZhbHVlIjoicmJtQjhNZW5YVmhsdkNEcGk5NFNnWVYwWEdQU0dFWlk5emFMVWIvOW5kSStnL3NnS0QvZERxOURENzdJb0FxZGVJQ01tNDZuWHV4YlhwWkNpVFl0eTJIWFVpaUpwSnJNTGM5VXFGTGQ4am5zQ3JYSzRzV1ZLdFhEUlNGd0JxeHEiLCJtYWMiOiIwMTYwYzYxMTU2OTEyZGU3NDNiYTQzNDZkNWY2NmM4YTlhNTYzNWFmNzhkYmY5NWMwMzMyMjQ0ZTcxMjVlMzliIiwidGFnIjoiIn0%3D; alpl_v2_front_session=eyJpdiI6IjhlWVVhbUJYMVoxNWk3Ujg1ZEplQlE9PSIsInZhbHVlIjoiUEhxZ3V3d0wrNlNVc2VrUHdRU1FXU0pPb29Cd2hCV1YwREVFTWF0VTJDaENzTnRITDkybytTUnV0RVNXU1hIZUZYYTVxdkdhbUZHSUFjTWJsaWZNTlZYaUNLMzY3RGVvWWE1UUY2b0NDZDdHSUdDQmhFajcySUVkN1dPanJnZjUiLCJtYWMiOiI4MTUyN2FjMmIwMzc5YzBhYjQwZjEzZmU5OTJiM2U1ZTZkMjA4NGU4MTBhZDg3NWQxOWM0YmU4ZWQ2NjBmMTQwIiwidGFnIjoiIn0%3D; a2cv2=eyJpdiI6ImkrajFuYlYydTJabE9peDNFUjJwdGc9PSIsInZhbHVlIjoiN0ZBeW9OVUp3cVgzNkNHbW5SeThXVVh2M3k4SnJGRmtFRytpUGo0NjZoY1djMDJjTVdhL1ppRE9DTkwzZmtQc3ovWWtOUURsaHpTb2hhK1BiTDhBVE9hbTE3WE55MDNCVmIyYUNWVENRMEE9IiwibWFjIjoiNWJlZWYyMzcyNGYwZWE3Nzc5YzJkOTdhNjFmMzM3N2YzNjhjNWUwMDVlZjRkNDkyYzc3OGRiYWZhZTk4Yjc0YiIsInRhZyI6IiJ9; device_uuid=eyJpdiI6IllTMDVkRFVnc2tpS1BJT2lESW5EcEE9PSIsInZhbHVlIjoiQk5xczlzK2pVZVdteDNkckFrSGhmNGxRa2x4U2p1MDIyMFFnUno3blpsem9Zem50QXJaMXczZmFZWjZSREN2ekZ5WmkrZDFKTEd2SkxEVGlUSnRqUytOQ3pGN1Qza0tNNm95L2twendqT0U9IiwibWFjIjoiMGMzOWEwYWU1YjVlNmNjZjdjMWVmY2ZhNWY1NzFiYjc1ZmIyMjA1ZjIwMjQ2MmUwMDUzMThiOGFjNWE5MDBjNSIsInRhZyI6IiJ9; AWSALB=kLHDekZFRyZ+s2WM2bTBDoJJSNMR4t+jNgK+luFCCiWldCddLiKi03vJNKxJ0d/ETq8p17aGo5Rn2JQKY6RezK8Zyn+J2jr0TGSiQBnERZoO7/qg9LVAtJBqZ+1e; AWSALBCORS=kLHDekZFRyZ+s2WM2bTBDoJJSNMR4t+jNgK+luFCCiWldCddLiKi03vJNKxJ0d/ETq8p17aGo5Rn2JQKY6RezK8Zyn+J2jr0TGSiQBnERZoO7/qg9LVAtJBqZ+1e"
+        "Cookie": "replace-with-your-provider-cookie-if-needed"
       }
     },
     "syosetu": {

--- a/daemon/docker-compose.yml
+++ b/daemon/docker-compose.yml
@@ -7,11 +7,12 @@ services:
     image: auto-novel-crawler:latest
     container_name: auto-novel-crawler
     ports:
-      - '3000:3000'
+      - '127.0.0.1:3000:3000'
 
     environment:
       - NODE_ENV=production
       - CONFIG_PATH=/app/config.json
+      - CRAWLER_ADMIN_TOKEN=${CRAWLER_ADMIN_TOKEN:-}
     volumes:
       - './config.json:/app/config.json'
       - './data:/app/data'

--- a/daemon/src/adminAuth.ts
+++ b/daemon/src/adminAuth.ts
@@ -1,0 +1,35 @@
+import { timingSafeEqual } from 'node:crypto';
+import type { RequestHandler } from 'express';
+
+const ADMIN_TOKEN_SCHEME = 'Bearer ';
+
+export function createAdminAuthMiddleware(adminToken: string): RequestHandler {
+  return (req, res, next) => {
+    const suppliedToken = readAdminToken(
+      req.header('authorization'),
+      req.header('x-admin-token'),
+    );
+
+    if (!suppliedToken || !tokensMatch(suppliedToken, adminToken)) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    next();
+  };
+}
+
+function readAdminToken(authorization?: string, headerToken?: string) {
+  if (authorization?.startsWith(ADMIN_TOKEN_SCHEME)) {
+    return authorization.slice(ADMIN_TOKEN_SCHEME.length);
+  }
+  return headerToken;
+}
+
+function tokensMatch(suppliedToken: string, expectedToken: string) {
+  const supplied = Buffer.from(suppliedToken);
+  const expected = Buffer.from(expectedToken);
+  return (
+    supplied.length === expected.length && timingSafeEqual(supplied, expected)
+  );
+}

--- a/daemon/src/config.ts
+++ b/daemon/src/config.ts
@@ -14,6 +14,7 @@ export const ConfigSchema = z
     host: z.string().default('127.0.0.1'),
     port: z.number().default(3000),
     proxyDbPath: z.string().default('crawler-proxies.db'),
+    adminToken: z.string().min(16).optional(),
     defaultProxies: z.array(ProxyConfigSchema).default([]),
     providerConfig: z
       .partialRecord(ProviderIdSchema, ProviderConfigSchema)
@@ -28,7 +29,8 @@ export const DEFAULT_CONFIG: AppConfig = ConfigSchema.parse({});
 export async function loadConfig(configPath: string): Promise<AppConfig> {
   const raw = await fs.readFile(configPath, 'utf-8').catch(() => null);
   const parsed = parseConfig(raw);
-  const config = ConfigSchema.parse(parsed);
+  const configInput = applyEnvOverrides(parsed);
+  const config = ConfigSchema.parse(configInput);
   if (shouldPersistDefaults(raw, parsed)) {
     const merged = { ...DEFAULT_CONFIG, ...parsed };
     await fs
@@ -60,6 +62,14 @@ function parseConfig(raw: string | null): Record<string, unknown> {
     );
   }
   return {};
+}
+
+function applyEnvOverrides(parsed: Record<string, unknown>) {
+  const adminToken = process.env.CRAWLER_ADMIN_TOKEN?.trim();
+  if (adminToken && !('adminToken' in parsed)) {
+    return { ...parsed, adminToken };
+  }
+  return parsed;
 }
 
 function shouldPersistDefaults(

--- a/daemon/src/index.ts
+++ b/daemon/src/index.ts
@@ -1,7 +1,8 @@
 import { Command } from 'commander';
 import { mapValues } from 'lodash-es';
-import { Server } from 'node:http';
+import { createServer, Server } from 'node:http';
 
+import { createAdminAuthMiddleware } from '@/adminAuth';
 import { loadConfig } from '@/config';
 import { createApp } from '@/createApp';
 import manifest from '@/package.json';
@@ -43,29 +44,38 @@ async function main() {
   const router = createCrawlerRouter(crawlerService);
   const proxyRouter = createProxyRouter(proxyManager);
   const app = createApp(config, { router });
-  app.use('/proxies', proxyRouter);
 
-  const server = app.listen(config.port, config.host, () => {
-    console.log(`Server is running on http://${config.host}:${config.port}`);
-  });
-
+  const server = createServer(app);
   const shutdown = createGracefulShutdown(server, [() => proxyStore.close()]);
 
-  app.post('/shutdown', async (req, res) => {
-    console.log('Shutdown requested via API');
+  if (config.adminToken) {
+    const requireAdminAuth = createAdminAuthMiddleware(config.adminToken);
+    app.use('/proxies', requireAdminAuth, proxyRouter);
 
-    res.status(202).json({
-      message: 'Server is shutting down...',
-      uptime: process.uptime(),
-      timestamp: Date.now(),
-    });
+    app.post('/shutdown', requireAdminAuth, async (req, res) => {
+      console.log('Shutdown requested via API');
 
-    setImmediate(() => {
-      shutdown('api-request', 0).catch((err) => {
-        console.error('Error during API shutdown:', err);
-        process.exit(1);
+      res.status(202).json({
+        message: 'Server is shutting down...',
+        uptime: process.uptime(),
+        timestamp: Date.now(),
+      });
+
+      setImmediate(() => {
+        shutdown('api-request', 0).catch((err) => {
+          console.error('Error during API shutdown:', err);
+          process.exit(1);
+        });
       });
     });
+  } else {
+    console.warn(
+      'Administrative endpoints (/proxies and /shutdown) are disabled. Set adminToken or CRAWLER_ADMIN_TOKEN to enable them.',
+    );
+  }
+
+  server.listen(config.port, config.host, () => {
+    console.log(`Server is running on http://${config.host}:${config.port}`);
   });
 
   try {

--- a/daemon/tests/admin-auth.test.ts
+++ b/daemon/tests/admin-auth.test.ts
@@ -1,0 +1,104 @@
+import Express from 'express';
+import { afterAll, describe, expect, test } from 'vitest';
+
+import { createAdminAuthMiddleware } from '@/adminAuth';
+import { createProxyRouter } from '@/services/proxy/routers';
+import type { ProxyManager } from '@/services/proxy/manager';
+
+const adminToken = 'test-admin-token-123';
+const servers: Array<{ close: () => Promise<void> }> = [];
+
+describe('admin authentication', () => {
+  afterAll(async () => {
+    await Promise.all(servers.map((server) => server.close()));
+  });
+
+  test('rejects unauthenticated proxy management requests', async () => {
+    const url = await createProxyTestServer();
+
+    const response = await fetch(`${url}/proxies`);
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'Unauthorized' });
+  });
+
+  test('allows proxy management requests with a bearer admin token', async () => {
+    const url = await createProxyTestServer();
+
+    const response = await fetch(`${url}/proxies`, {
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual([
+      {
+        id: 1,
+        config: {
+          protocol: 'http',
+          host: 'proxy.example',
+          port: 8080,
+          username: 'user',
+          password: 'pass',
+        },
+        failCount: 0,
+        successCount: 0,
+        cooldownUntil: null,
+        lastUsedAt: null,
+      },
+    ]);
+  });
+});
+
+async function createProxyTestServer() {
+  const app = Express();
+  app.use(
+    '/proxies',
+    createAdminAuthMiddleware(adminToken),
+    createProxyRouter(createStubProxyManager()),
+  );
+
+  const server = app.listen(0, '127.0.0.1');
+  await new Promise<void>((resolve) => server.once('listening', resolve));
+  servers.push({
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Unexpected server address');
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+function createStubProxyManager(): ProxyManager {
+  return {
+    list: () => [
+      {
+        id: 1,
+        config: {
+          protocol: 'http',
+          host: 'proxy.example',
+          port: 8080,
+          username: 'user',
+          password: 'pass',
+        },
+        failCount: 0,
+        successCount: 0,
+        cooldownUntil: null,
+        lastUsedAt: null,
+      },
+    ],
+    add: (config) => ({
+      id: 2,
+      config,
+      failCount: 0,
+      successCount: 0,
+      cooldownUntil: null,
+      lastUsedAt: null,
+    }),
+    remove: () => undefined,
+  } as ProxyManager;
+}


### PR DESCRIPTION
### Motivation
- The crawler daemon exposed unauthenticated administrative APIs (`/proxies` and `/shutdown`) and example configs that made them reachable from the network, risking credential disclosure and remote control.\n
### Description
- Add a constant-time admin-token middleware `createAdminAuthMiddleware` that accepts `Authorization: Bearer <token>` or `X-Admin-Token` and returns `401` for missing/invalid credentials.\n
- Protect the proxy-management router and shutdown endpoint by mounting them only when an `adminToken` is configured, otherwise the endpoints are disabled.\n
- Add `adminToken` to the app config schema and allow overriding it from the `CRAWLER_ADMIN_TOKEN` environment variable.\n
- Harden example deployment and configs by binding the example service to `127.0.0.1`, adding `CRAWLER_ADMIN_TOKEN` passthrough in `docker-compose.yml`, and removing a sensitive example `Cookie` value in `config.example.json`.\n
- Add documentation to `daemon/README.md` explaining the admin-token requirement and add a Vitest test exercising the admin middleware for the proxy routes.\n
Files changed include `daemon/src/adminAuth.ts`, `daemon/src/index.ts`, `daemon/src/config.ts`, `daemon/config.example.json`, `daemon/docker-compose.yml`, `daemon/README.md`, and `daemon/tests/admin-auth.test.ts`.

### Testing
- Ran `prettier --check` on touched files and it passed.\n
- Ran `git diff --check` and a grep-based sanity check to ensure no unauthenticated admin mounts remain, both checks passed.\n
- Added `daemon/tests/admin-auth.test.ts` covering unauthenticated rejection and bearer-token acceptance, but running the test suite in this environment failed because the container Node is `v20.20.2` while the package requests `node >=22.5.0` and the `daemon` package is not set up as an independent workspace project here; therefore the Vitest tests could not be executed in this CI environment.\n
- Could not run the `pwsh ./scripts/check-fork-invariants.ps1` step because `pwsh` is not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a055e51817083229f9de513e3792f1d)